### PR TITLE
Replace build-base with the bare necessary dependencies

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        apk add build-base git bash
+        apk add make git bash
     
 
     - name: Compile project


### PR DESCRIPTION
Replacing `build-base` with `make mpfr gmp mpc1` reduces the amount of installed packages from 212mb to 25mb.


I really think `mpfr gmp mpc1` shouldn't be necessary as `psp-gcc` needs them to run. The docker layer is unusable at its current state without them.